### PR TITLE
Build RITE for aarch64 as well

### DIFF
--- a/tools/rack/pom.xml
+++ b/tools/rack/pom.xml
@@ -454,6 +454,11 @@
               <environment>
                 <os>macosx</os>
                 <ws>cocoa</ws>
+                <arch>aarch64</arch>
+              </environment>
+              <environment>
+                <os>macosx</os>
+                <ws>cocoa</ws>
                 <arch>x86_64</arch>
               </environment>
               <environment>

--- a/tools/rack/rack.targetplatform/rack.targetplatform.target
+++ b/tools/rack/rack.targetplatform/rack.targetplatform.target
@@ -27,7 +27,7 @@
       <unit id="org.eclipse.sirius.runtime.ide.ui.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.uml2.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.zest.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/releases/2021-03/"/>
+      <repository location="https://download.eclipse.org/releases/2021-06/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="com.google.gson" version="0.0.0"/>


### PR DESCRIPTION
rack/pom.xml: Add macosx cocoa aarch64 to environments.

rack.targetplatform.target: Bump Eclipse to 2021-06.