### PR TITLE
Update RITE to Java 17 and SADL 3.6.0-SNAPSHOT

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         distribution: [ temurin ]
-        java-version: [ 11 ]
+        java-version: [ 17 ]
         os: [ ubuntu-22.04 ]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         distribution: [ temurin ]
-        java-version: [ 11 ]
+        java-version: [ 17 ]
         os: [ ubuntu-22.04 ]
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         distribution: [ temurin ]
-        java-version: [ 11 ]
+        java-version: [ 17 ]
         os: [ ubuntu-22.04 ]
 
     steps:
@@ -31,7 +31,7 @@ jobs:
         java-version: ${{ matrix.java-version }}
 
     - name: Build RITE source
-      run: mvn -B -f tools/rack/pom.xml package -Dtycho.localArtifacts=ignore
+      run: mvn -B package -f tools/rack/pom.xml -Dtycho.localArtifacts=ignore
 
     - name: Rename RITE zips
       run: |

--- a/tools/rack/README.md
+++ b/tools/rack/README.md
@@ -7,25 +7,26 @@ RACK IDE bundles the [Semantic Application Design Language (SADL)](http://sadl.s
 Prerequisites:
 -------------
 1) Have Rack-in-a-box running ([Instructions here](https://github.com/ge-high-assurance/RACK/wiki/02-Run-a-RACK-Box-container)).
-   
-2) Have Java 11 installed on your machine
-    Just follow the JDK 11 installation steps at : 
-     
-     https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html
+
+2) Have Java 17 installed on your machine
+    Just follow the JDK 17 installation steps at :
+
+     https://www.oracle.com/java/technologies/downloads/
+
 3) Have Maven installed:
 
    On Mac: ```brew install maven```
-   
+
    On Windows: https://maven.apache.org/install.html
-     
+
 
 Steps to use the RACK IDE as an Eclipse Instance
 ---------------------------------------------------
 1) Configure Core and Overlay Projects in the RACK Preference Page, click Apply and Close
     a) Core project is typical RACK-Ontology SADL project from the RACK github repo
-    b) Overlay project can be GE-Ontology or SRI-Ontology and so on  
-    
-2) From the RACK Panel, click on Upload Overlay Ontology 
+    b) Overlay project can be GE-Ontology or SRI-Ontology and so on
+
+2) From the RACK Panel, click on Upload Overlay Ontology
 
 3) Click on Generate Nodegroups to generate all nodegroups locally: the nodegroups (json files) will be generated in the Overlay Project's nodegroup folder
 
@@ -33,11 +34,11 @@ Steps to use the RACK IDE as an Eclipse Instance
 
 5) Try Loading all the nodegroups: the nodegroups must be filtered into Core, Overlay and Other nodegroups
 
-6) Working with nodegroups: 
+6) Working with nodegroups:
      a) Can check a nodegoup, right-click on it and select "Create instance Data" to create a CSV file associated with the nodegroup
 	 b) The CSV file will be created in the InstanceData folder
 	 c) After making some entries into the CSV table, right click on the table -> Ingest CSV to RACK to directly upload the CSV to RACK
-	 d) After uploading CSV, we can quickly check whether the data was indeed uploading, by right-clicking on nodegroup -> Query Nodegroup, to see its 
+	 d) After uploading CSV, we can quickly check whether the data was indeed uploading, by right-clicking on nodegroup -> Query Nodegroup, to see its
 	    query results
 	    Note that: data ingestion is not always guaranteed to work as there might be dependencies between nodegroups inorder to successfully ingest data
 	    This is part of future work
@@ -46,24 +47,22 @@ Steps to use the RACK IDE as an Eclipse Instance
 For Developers
 --------------
 1) Follow the [rack-in-a-box instructions](https://github.com/ge-high-assurance/RACK/wiki/02-Run-a-RACK-Box-container#step-2-download-a-rack-box-container-image) to start the RACK as a docker container
-2) Download [Eclipse IDE for Java developers 2022-03](https://www.eclipse.org/downloads/packages/release/2022-03/r/eclipse-ide-java-developers)  
+2) Download [Eclipse IDE for Java developers 2022-12](https://www.eclipse.org/downloads/packages/release/2022-12/r/eclipse-ide-java-developers)
    This version of eclipse was used to test the RACK plugin, other versions may work
 3) Import the repo's `/assurance-case-pipeline/tools/rack` folder as a Maven project in Eclipse by navigating to `Application Menu Bar > File > Import > Existing Maven Projects`
 4) Update targetplatform
     a) Open rack.targetplatform project, and double-click on `rack.targetplatform.target` file. The target defintion UI (pictured below) should appear. If it does not, follow the Eclipse PDE installation instructions at the end.
     <img width="947" alt="image" src="https://user-images.githubusercontent.com/44778536/199801631-27d74fe5-809d-47f5-9d81-8a5c70c7f0f2.png">
-    b) Click on Update Target Platform (or Reload Target Platform) in the top right corner of the target definition UI (pictured above). 
+    b) Click on Update Target Platform (or Reload Target Platform) in the top right corner of the target definition UI (pictured above).
        Note: This step will download all required dependencies on initialization
 5) From a command line, navigate to the rack directory : `/assurance-case-pipeline/tools/rack`
 6) Run `mvn clean install`. This will build all the projects inside rack folder and also the plugin
-7) From the Eclipse IDE, select all projects and `right-click on any selected project > Maven > Update Project...`. After the update finishes, `right-click on rack.plugin > Run As > Run Configurations... > Double click Eclipse Application > Run` (pictured below). 	    	Subsequent runs can use the same configuration. This will launch the RACK Plugin in a SADL Eclipse Environment 
+7) From the Eclipse IDE, select all projects and `right-click on any selected project > Maven > Update Project...`. After the update finishes, `right-click on rack.plugin > Run As > Run Configurations... > Double click Eclipse Application > Run` (pictured below). 	    	Subsequent runs can use the same configuration. This will launch the RACK Plugin in a SADL Eclipse Environment
 	<img width="1062" alt="image" src="https://user-images.githubusercontent.com/44778536/199816508-9b100b99-74b3-432a-96d2-9c8bd3022906.png">
 
 #### Eclipse IDE Installation Instructions:
 *Access to the Eclipse marketplace is required. For GE users, disable corporate proxies*
-1. From eclipse open the eclipse marketplace by clicking `App Menu Bar > Help > Eclipse Marketplace...` 
-2. In the Search tab, search for and install the Eclipse PDE (Plugin Development Environment) latest 
+1. From eclipse open the eclipse marketplace by clicking `App Menu Bar > Help > Eclipse Marketplace...`
+2. In the Search tab, search for and install the Eclipse PDE (Plugin Development Environment) latest
 3. Click install
 4. After the plugin is installed restart Eclipse
-
-

--- a/tools/rack/pom.xml
+++ b/tools/rack/pom.xml
@@ -3,13 +3,13 @@
      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <!-- Define ourselves -->
+  <!-- Define our GAV coordinates -->
   <groupId>com.ge.research.rack</groupId>
   <artifactId>rack</artifactId>
   <version>0.5.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <!-- Build all modules in one place -->
+  <!-- Build our modules -->
   <modules>
     <module>rack.feature</module>
     <module>rack.plugin</module>
@@ -55,18 +55,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */</copyright.license>
     <!-- Settings of Maven plugins -->
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>17</maven.compiler.release>
     <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
     <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- For multiple dependencies which use the same version -->
     <version.javafx>20.0.1</version.javafx>
     <version.rack>${project.version}</version.rack>
     <version.surefire>3.1.0</version.surefire>
-    <version.tycho>2.7.5</version.tycho>
+    <version.tycho>3.0.4</version.tycho>
   </properties>
 
   <!-- Set all dependency versions in one place -->
@@ -256,7 +256,7 @@
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
-          <version>2.33.0</version>
+          <version>2.36.0</version>
           <configuration>
             <java>
               <includes>
@@ -428,7 +428,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.14.2</version>
+          <version>2.15.0</version>
         </plugin>
         <plugin>
           <?m2e ignore?>
@@ -531,9 +531,9 @@
             </execution>
           </executions>
         </plugin>
-        <!-- To skip running (and compiling) tests, use: -Dmaven.test.skip
-             To skip tests, but still compile them, use: -DskipTests
-             To run all tests but only fail at end, use: -fae -->
+        <!-- To skip running (and compiling) tests, use: -Dmaven.test.skip -->
+        <!-- To skip tests, but still compile them, use: -DskipTests -->
+        <!-- To run all tests but only fail at end, use: -fae -->
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-surefire-plugin</artifactId>
@@ -550,11 +550,6 @@
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-versions-plugin</artifactId>
-          <version>${version.tycho}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.eclipse.tycho.extras</groupId>
-          <artifactId>tycho-source-feature-plugin</artifactId>
           <version>${version.tycho}</version>
         </plugin>
       </plugins>

--- a/tools/rack/rack.plugin/META-INF/MANIFEST.MF
+++ b/tools/rack/rack.plugin/META-INF/MANIFEST.MF
@@ -90,7 +90,7 @@ Bundle-ClassPath: .,
  lib/opencsv.jar,
  lib/sparqlGraphLibrary.jar,
  lib/viz.js-graphviz-java.jar
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: com.ge.research.rack.Activator
 Automatic-Module-Name: rack.plugin

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/Activator.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/Activator.java
@@ -33,6 +33,7 @@ package com.ge.research.rack;
 
 import com.ge.research.rack.utils.RackConsole;
 import com.ge.research.rack.views.RackPreferencePage;
+
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/BuildIngestionNodegroupsHandler.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/BuildIngestionNodegroupsHandler.java
@@ -38,9 +38,7 @@ import com.ge.research.rack.utils.ProjectUtils;
 import com.ge.research.rack.utils.RackConsole;
 import com.ge.research.rack.views.RackPreferencePage;
 import com.ge.research.rack.views.ViewUtils;
-import java.io.File;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
+
 import org.apache.commons.io.FileUtils;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
@@ -52,6 +50,10 @@ import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.IJobChangeListener;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.ui.progress.WorkbenchJob;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
 
 public class BuildIngestionNodegroupsHandler extends AbstractHandler {
 

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/ClearAllHandler.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/ClearAllHandler.java
@@ -37,7 +37,7 @@ import com.ge.research.rack.views.ViewUtils;
 import com.ge.research.semtk.nodeGroupStore.client.NodeGroupStoreRestClient;
 import com.ge.research.semtk.resultSet.Table;
 import com.ge.research.semtk.resultSet.TableResultSet;
-import java.util.ArrayList;
+
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
@@ -50,6 +50,8 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.ui.console.IConsoleConstants;
 import org.eclipse.ui.console.IConsoleView;
 import org.eclipse.ui.handlers.HandlerUtil;
+
+import java.util.ArrayList;
 
 public class ClearAllHandler extends AbstractHandler {
 

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/HandlerUtils.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/HandlerUtils.java
@@ -37,9 +37,7 @@ import com.ge.research.rack.utils.RackConsole;
 import com.ge.research.rack.views.NodegroupsView;
 import com.ge.research.rack.views.OntologyTreeView;
 import com.ge.research.rack.views.ViewUtils;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.resources.IFile;
@@ -54,6 +52,10 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.handlers.HandlerUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class HandlerUtils {
 

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/IngestInstanceDataHandler.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/IngestInstanceDataHandler.java
@@ -42,15 +42,7 @@ import com.ge.research.semtk.nodeGroupStore.client.NodeGroupStoreRestClient;
 import com.ge.research.semtk.sparqlX.SparqlConnection;
 import com.ge.research.semtk.sparqlX.client.SparqlQueryClient;
 import com.opencsv.CSVReader;
-import java.io.File;
-import java.io.FileReader;
-import java.nio.charset.Charset;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
 import org.apache.commons.io.FileUtils;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
@@ -67,6 +59,16 @@ import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.TreePath;
 import org.eclipse.jface.viewers.TreeSelection;
 import org.eclipse.ui.handlers.HandlerUtil;
+
+import java.io.File;
+import java.io.FileReader;
+import java.nio.charset.Charset;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class IngestInstanceDataHandler extends AbstractHandler {
     private static String manifestPath = "";

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/IngestTemplatesHandler.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/IngestTemplatesHandler.java
@@ -37,9 +37,7 @@ import com.ge.research.rack.views.RackSettingPanel;
 import com.ge.research.semtk.load.utility.SparqlGraphJson;
 import com.ge.research.semtk.nodeGroupStore.client.NodeGroupStoreRestClient;
 import com.ge.research.semtk.sparqlX.SparqlConnection;
-import java.io.File;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
+
 import org.apache.commons.io.FileUtils;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
@@ -56,6 +54,10 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.console.IConsoleConstants;
 import org.eclipse.ui.console.IConsoleView;
 import org.eclipse.ui.handlers.HandlerUtil;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
 
 public class IngestTemplatesHandler extends AbstractHandler {
 

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/JavaFXAppLaunchManager.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/JavaFXAppLaunchManager.java
@@ -35,6 +35,7 @@ import com.ge.research.rack.autoGsn.viewManagers.AutoGsnViewsManager;
 import com.ge.research.rack.autoGsn.viewManagers.GsnTreeViewManager;
 import com.ge.research.rack.report.viewManagers.ReportViewsManager;
 import com.ge.research.rack.views.RibView;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.stage.Stage;

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/LoadAssuranceCaseHandler.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/LoadAssuranceCaseHandler.java
@@ -33,9 +33,7 @@ package com.ge.research.rack;
 
 import com.ge.research.rack.utils.*;
 import com.ge.research.rack.views.AssuranceCaseTree;
-import java.io.*;
-import java.util.HashMap;
-import java.util.HashSet;
+
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.ontology.OntModel;
@@ -59,6 +57,10 @@ import org.eclipse.jface.viewers.TreeSelection;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.handlers.HandlerUtil;
+
+import java.io.*;
+import java.util.HashMap;
+import java.util.HashSet;
 
 public class LoadAssuranceCaseHandler extends AbstractHandler {
 

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/QueryNodegroupsSelectViewHandler.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/QueryNodegroupsSelectViewHandler.java
@@ -34,10 +34,7 @@ package com.ge.research.rack;
 import com.ge.research.rack.autoGsn.utils.CustomFileUtils;
 import com.ge.research.rack.autoGsn.utils.CustomStringUtils;
 import com.ge.research.rack.report.utils.RackQueryUtils;
-import java.io.File;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
+
 import javafx.application.Application;
 import javafx.concurrent.Task;
 import javafx.fxml.FXML;
@@ -50,10 +47,16 @@ import javafx.scene.control.ProgressIndicator;
 import javafx.stage.FileChooser;
 import javafx.stage.FileChooser.ExtensionFilter;
 import javafx.stage.Stage;
+
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.osgi.framework.Bundle;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Saswata Paul

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/RackSettingHandler.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/RackSettingHandler.java
@@ -32,6 +32,7 @@
 package com.ge.research.rack;
 
 import com.ge.research.rack.views.RackSettingPanel;
+
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/RefreshHandler.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/RefreshHandler.java
@@ -34,6 +34,7 @@ package com.ge.research.rack;
 import com.ge.research.rack.utils.IngestionTemplateUtil;
 import com.ge.research.rack.utils.RackConsole;
 import com.ge.research.rack.views.OntologyTreeView;
+
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/RegenerateManifest.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/RegenerateManifest.java
@@ -31,18 +31,6 @@
  */
 package com.ge.research.rack;
 
-import java.io.ByteArrayInputStream;
-import java.io.CharArrayWriter;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
@@ -59,260 +47,283 @@ import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.DumperOptions.FlowStyle;
 import org.yaml.snakeyaml.Yaml;
 
+import java.io.ByteArrayInputStream;
+import java.io.CharArrayWriter;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
 public class RegenerateManifest extends AbstractHandler {
 
-	static final String DEFAULT_MODEL_GRAPH = "http://rack001/model";
-	static final String DEFAULT_DATA_GRAPH = "http://rack001/data";
-	static final String MANIFEST_YAML_NAME = "manifest.yaml";
-	static final String DATA_YAML_NAME = "data.yaml";
-	static final String MODEL_YAML_NAME = "model.yaml";
-	static final String NODEGROUPS_NAME = "store_data.csv";
-	static final String COPY_TO_GRAPH_KEY = "copy-to-graph";
-	static final String PERFORM_ENTITY_RESOLUTION_KEY = "perform-entity-resolution";
+    static final String DEFAULT_MODEL_GRAPH = "http://rack001/model";
+    static final String DEFAULT_DATA_GRAPH = "http://rack001/data";
+    static final String MANIFEST_YAML_NAME = "manifest.yaml";
+    static final String DATA_YAML_NAME = "data.yaml";
+    static final String MODEL_YAML_NAME = "model.yaml";
+    static final String NODEGROUPS_NAME = "store_data.csv";
+    static final String COPY_TO_GRAPH_KEY = "copy-to-graph";
+    static final String PERFORM_ENTITY_RESOLUTION_KEY = "perform-entity-resolution";
 
-	final Set<IProject> visitedProjects = new HashSet<>();
+    final Set<IProject> visitedProjects = new HashSet<>();
 
-	// Open a YAML file and deserialize it as a Java object
-	static Object openYamlResource(IResource resource) throws CoreException {
-		final IFile file = resource.getProject().getFile(resource.getProjectRelativePath());
-		final Yaml yaml = new Yaml();
-		return yaml.load(file.getContents());
-	}
+    // Open a YAML file and deserialize it as a Java object
+    static Object openYamlResource(IResource resource) throws CoreException {
+        final IFile file = resource.getProject().getFile(resource.getProjectRelativePath());
+        final Yaml yaml = new Yaml();
+        return yaml.load(file.getContents());
+    }
 
-	static void extendFootprintSet(Object object, Set<String> set) {
-		if (object instanceof Collection) {
-			for (Object entry : (Collection<?>) object) {
-				if (entry instanceof String) {
-					set.add((String) entry);
-				}
-			}
-		}
-	}
+    static void extendFootprintSet(Object object, Set<String> set) {
+        if (object instanceof Collection) {
+            for (Object entry : (Collection<?>) object) {
+                if (entry instanceof String) {
+                    set.add((String) entry);
+                }
+            }
+        }
+    }
 
-	// Generate the list of all relative paths to manifests used by this project
-	List<String> getManifests(IProject project, Set<String> modelGraphs, Set<String> dataGraphs)
-			throws ExecutionException {
+    // Generate the list of all relative paths to manifests used by this project
+    List<String> getManifests(IProject project, Set<String> modelGraphs, Set<String> dataGraphs)
+            throws ExecutionException {
 
-		// getLocation is used instead of getFullPath for manifests because manifests
-		// link across project boundaries and are access by tooling that is unaware of
-		// the Eclipse workspace structure.
+        // getLocation is used instead of getFullPath for manifests because manifests
+        // link across project boundaries and are access by tooling that is unaware of
+        // the Eclipse workspace structure.
 
-		final List<String> manifests = new ArrayList<>();
-		final IPath projectPath = project.getLocation();
+        final List<String> manifests = new ArrayList<>();
+        final IPath projectPath = project.getLocation();
 
-		try {
-			final IProject[] referencedProjects = project.getReferencedProjects();
-			for (IProject referencedProject : referencedProjects) {
+        try {
+            final IProject[] referencedProjects = project.getReferencedProjects();
+            for (IProject referencedProject : referencedProjects) {
 
-				// Update the manifest first if it hasn't been updated yet
-				regenerateProjectManifest(referencedProject);
+                // Update the manifest first if it hasn't been updated yet
+                regenerateProjectManifest(referencedProject);
 
-				final IFile manifestFile = referencedProject.getFile(MANIFEST_YAML_NAME);
-				if (manifestFile.exists()) {
-					final IPath manifestPath = manifestFile.getLocation();
-					manifests.add(manifestPath.makeRelativeTo(projectPath).toString());
+                final IFile manifestFile = referencedProject.getFile(MANIFEST_YAML_NAME);
+                if (manifestFile.exists()) {
+                    final IPath manifestPath = manifestFile.getLocation();
+                    manifests.add(manifestPath.makeRelativeTo(projectPath).toString());
 
-					final Object manifestObj = openYamlResource(manifestFile);
-					if (manifestObj instanceof Map) {
-						final Map<?, ?> manifest = (Map<?, ?>) manifestObj;
-						final Object footprintObj = manifest.get("footprint");
-						if (footprintObj instanceof Map) {
-							final Map<?, ?> footprint = (Map<?, ?>) footprintObj;
-							extendFootprintSet(footprint.get("model-graphs"), modelGraphs);
-							extendFootprintSet(footprint.get("data-graphs"), dataGraphs);
-						}
-					}
-				}
-			}
-		} catch (CoreException e) {
-			throw new ExecutionException("Failed to check subproject manifest.yaml", e);
-		}
-		return manifests;
-	}
+                    final Object manifestObj = openYamlResource(manifestFile);
+                    if (manifestObj instanceof Map) {
+                        final Map<?, ?> manifest = (Map<?, ?>) manifestObj;
+                        final Object footprintObj = manifest.get("footprint");
+                        if (footprintObj instanceof Map) {
+                            final Map<?, ?> footprint = (Map<?, ?>) footprintObj;
+                            extendFootprintSet(footprint.get("model-graphs"), modelGraphs);
+                            extendFootprintSet(footprint.get("data-graphs"), dataGraphs);
+                        }
+                    }
+                }
+            }
+        } catch (CoreException e) {
+            throw new ExecutionException("Failed to check subproject manifest.yaml", e);
+        }
+        return manifests;
+    }
 
-	// Replace the manifest.yaml for project using the Java object content.
-	static void writeManifest(IProject project, Object content) throws ExecutionException {
-		// Write YAML to disk
-		final IFile manifestFile = project.getFile(MANIFEST_YAML_NAME);
-		try {
-			// Generate prettier, human readable YAML
-			final DumperOptions options = new DumperOptions();
-			options.setDefaultFlowStyle(FlowStyle.BLOCK);
+    // Replace the manifest.yaml for project using the Java object content.
+    static void writeManifest(IProject project, Object content) throws ExecutionException {
+        // Write YAML to disk
+        final IFile manifestFile = project.getFile(MANIFEST_YAML_NAME);
+        try {
+            // Generate prettier, human readable YAML
+            final DumperOptions options = new DumperOptions();
+            options.setDefaultFlowStyle(FlowStyle.BLOCK);
 
-			final Yaml yaml = new Yaml(options);
-			final CharArrayWriter writer = new CharArrayWriter();
-			yaml.dump(content, writer);
+            final Yaml yaml = new Yaml(options);
+            final CharArrayWriter writer = new CharArrayWriter();
+            yaml.dump(content, writer);
 
-			final InputStream source = new ByteArrayInputStream(writer.toString().getBytes());
-			final boolean force = false;
-			final boolean keep_history = true;
-			manifestFile.setContents(source, force, keep_history, null);
-		} catch (CoreException e) {
-			throw new ExecutionException("Failed writing final manifest.yaml output", e);
-		}
-	}
+            final InputStream source = new ByteArrayInputStream(writer.toString().getBytes());
+            final boolean force = false;
+            final boolean keep_history = true;
+            manifestFile.setContents(source, force, keep_history, null);
+        } catch (CoreException e) {
+            throw new ExecutionException("Failed writing final manifest.yaml output", e);
+        }
+    }
 
-	void regenerateProjectManifest(IProject project) throws ExecutionException {
+    void regenerateProjectManifest(IProject project) throws ExecutionException {
 
-		if (!project.isOpen() || !visitedProjects.add(project)) {
-			return;
-		}
+        if (!project.isOpen() || !visitedProjects.add(project)) {
+            return;
+        }
 
-		final IFile manifestResource = project.getFile(MANIFEST_YAML_NAME);
-		if (!manifestResource.exists()) {
-			return;
-		}
+        final IFile manifestResource = project.getFile(MANIFEST_YAML_NAME);
+        if (!manifestResource.exists()) {
+            return;
+        }
 
-		final Object manifestYaml;
-		try {
-			manifestYaml = openYamlResource(manifestResource);
-		} catch (CoreException e) {
-			throw new ExecutionException("Failed to open preexisting manifest.yaml", e);
-		}
+        final Object manifestYaml;
+        try {
+            manifestYaml = openYamlResource(manifestResource);
+        } catch (CoreException e) {
+            throw new ExecutionException("Failed to open preexisting manifest.yaml", e);
+        }
 
-		String copyToGraph = null;
-		String performEntityResolution = null;
+        String copyToGraph = null;
+        String performEntityResolution = null;
 
-		if (manifestYaml instanceof Map) {
-			Map<?, ?> map = (Map<?, ?>) manifestYaml;
+        if (manifestYaml instanceof Map) {
+            Map<?, ?> map = (Map<?, ?>) manifestYaml;
 
-			final Object copyToGraphObj = map.get(COPY_TO_GRAPH_KEY);
-			if (copyToGraphObj instanceof String) {
-				copyToGraph = (String) copyToGraphObj;
-			}
+            final Object copyToGraphObj = map.get(COPY_TO_GRAPH_KEY);
+            if (copyToGraphObj instanceof String) {
+                copyToGraph = (String) copyToGraphObj;
+            }
 
-			final Object performEntityResolutionObj = map.get(PERFORM_ENTITY_RESOLUTION_KEY);
-			if (performEntityResolutionObj instanceof String) {
-				performEntityResolution = (String) performEntityResolutionObj;
-			}
-		}
+            final Object performEntityResolutionObj = map.get(PERFORM_ENTITY_RESOLUTION_KEY);
+            if (performEntityResolutionObj instanceof String) {
+                performEntityResolution = (String) performEntityResolutionObj;
+            }
+        }
 
-		final Set<String> modelGraphs = new TreeSet<>();
-		final Set<String> dataGraphs = new TreeSet<>();
-		final List<String> models = new ArrayList<>();
-		final List<String> datas = new ArrayList<>();
-		final List<String> manifests = getManifests(project, modelGraphs, dataGraphs);
-		final List<String> nodegroups = new ArrayList<>();
+        final Set<String> modelGraphs = new TreeSet<>();
+        final Set<String> dataGraphs = new TreeSet<>();
+        final List<String> models = new ArrayList<>();
+        final List<String> datas = new ArrayList<>();
+        final List<String> manifests = getManifests(project, modelGraphs, dataGraphs);
+        final List<String> nodegroups = new ArrayList<>();
 
-		final IResourceProxyVisitor visitor = (IResourceProxy proxy) -> {
-			final String name = proxy.getName();
+        final IResourceProxyVisitor visitor =
+                (IResourceProxy proxy) -> {
+                    final String name = proxy.getName();
 
-			// Handle data sets
-			if (name.equals(DATA_YAML_NAME)) {
-				datas.add(proxy.requestFullPath().makeRelativeTo(project.getFullPath()).toString());
+                    // Handle data sets
+                    if (name.equals(DATA_YAML_NAME)) {
+                        datas.add(
+                                proxy.requestFullPath()
+                                        .makeRelativeTo(project.getFullPath())
+                                        .toString());
 
-				final Object dataYaml = openYamlResource(proxy.requestResource());
-				if (dataYaml instanceof Map) {
-					final Map<?, ?> map = (Map<?, ?>) dataYaml;
-					final Object dataGraph = map.get("data-graph");
+                        final Object dataYaml = openYamlResource(proxy.requestResource());
+                        if (dataYaml instanceof Map) {
+                            final Map<?, ?> map = (Map<?, ?>) dataYaml;
+                            final Object dataGraph = map.get("data-graph");
 
-					if (dataGraph == null) {
-						dataGraphs.add(DEFAULT_DATA_GRAPH);
-					} else if (dataGraph instanceof String) {
-						dataGraphs.add((String) dataGraph);
-					}
-				}
+                            if (dataGraph == null) {
+                                dataGraphs.add(DEFAULT_DATA_GRAPH);
+                            } else if (dataGraph instanceof String) {
+                                dataGraphs.add((String) dataGraph);
+                            }
+                        }
 
-				// Handle model sets
-			} else if (name.equals(MODEL_YAML_NAME)) {
-				models.add(proxy.requestFullPath().makeRelativeTo(project.getFullPath()).toString());
+                        // Handle model sets
+                    } else if (name.equals(MODEL_YAML_NAME)) {
+                        models.add(
+                                proxy.requestFullPath()
+                                        .makeRelativeTo(project.getFullPath())
+                                        .toString());
 
-				final Object modelYaml = openYamlResource(proxy.requestResource());
-				if (modelYaml instanceof Map) {
-					final Map<?, ?> map = (Map<?, ?>) modelYaml;
-					final Object modelGraph = map.get("model-graph");
-					if (modelGraph == null) {
-						modelGraphs.add(DEFAULT_MODEL_GRAPH);
-					} else if (modelGraph instanceof String) {
-						modelGraphs.add((String) modelGraph);
-					}
-				}
+                        final Object modelYaml = openYamlResource(proxy.requestResource());
+                        if (modelYaml instanceof Map) {
+                            final Map<?, ?> map = (Map<?, ?>) modelYaml;
+                            final Object modelGraph = map.get("model-graph");
+                            if (modelGraph == null) {
+                                modelGraphs.add(DEFAULT_MODEL_GRAPH);
+                            } else if (modelGraph instanceof String) {
+                                modelGraphs.add((String) modelGraph);
+                            }
+                        }
 
-				// Handle Nodegroups
-			} else if (name.equals(NODEGROUPS_NAME)) {
-				nodegroups.add(
-						proxy.requestFullPath().makeRelativeTo(project.getFullPath()).removeLastSegments(1).toString());
-			}
+                        // Handle Nodegroups
+                    } else if (name.equals(NODEGROUPS_NAME)) {
+                        nodegroups.add(
+                                proxy.requestFullPath()
+                                        .makeRelativeTo(project.getFullPath())
+                                        .removeLastSegments(1)
+                                        .toString());
+                    }
 
-			// True means to continue into any children of a directory
-			return true;
-		};
+                    // True means to continue into any children of a directory
+                    return true;
+                };
 
-		try {
-			// Recursively walk all the project resources using visitor as defined above
-			project.accept(visitor, IContainer.NONE);
-		} catch (CoreException e) {
-			throw new ExecutionException("Failed traversing project resources", e);
-		}
+        try {
+            // Recursively walk all the project resources using visitor as defined above
+            project.accept(visitor, IContainer.NONE);
+        } catch (CoreException e) {
+            throw new ExecutionException("Failed traversing project resources", e);
+        }
 
-		// Top-level contents of the generated manifest.yaml
-		// LinkedHashMap used to ensure output ordering matches generated ordering
-		final Map<String, Object> content = new LinkedHashMap<>();
+        // Top-level contents of the generated manifest.yaml
+        // LinkedHashMap used to ensure output ordering matches generated ordering
+        final Map<String, Object> content = new LinkedHashMap<>();
 
-		// name:
-		content.put("name", project.getName());
+        // name:
+        content.put("name", project.getName());
 
-		try {
-			final String description = project.getDescription().getComment();
-			if (!description.isBlank()) {
-				content.put("description", description);
-			}
-		} catch (CoreException e) {
-		}
+        try {
+            final String description = project.getDescription().getComment();
+            if (!description.isBlank()) {
+                content.put("description", description);
+            }
+        } catch (CoreException e) {
+        }
 
-		// footprint:
-		final Map<String, Object> footprint = new LinkedHashMap<>();
-		content.put("footprint", footprint);
-		if (!modelGraphs.isEmpty()) {
-			footprint.put("model-graphs", modelGraphs.toArray());
-		}
-		if (!dataGraphs.isEmpty()) {
-			footprint.put("data-graphs", dataGraphs.toArray());
-		}
+        // footprint:
+        final Map<String, Object> footprint = new LinkedHashMap<>();
+        content.put("footprint", footprint);
+        if (!modelGraphs.isEmpty()) {
+            footprint.put("model-graphs", modelGraphs.toArray());
+        }
+        if (!dataGraphs.isEmpty()) {
+            footprint.put("data-graphs", dataGraphs.toArray());
+        }
 
-		// steps:
-		final List<Map<String, String>> steps = new ArrayList<>();
-		content.put("steps", steps);
+        // steps:
+        final List<Map<String, String>> steps = new ArrayList<>();
+        content.put("steps", steps);
 
-		// all manifest entries first
-		for (String path : manifests) {
-			steps.add(Collections.singletonMap("manifest", path));
-		}
+        // all manifest entries first
+        for (String path : manifests) {
+            steps.add(Collections.singletonMap("manifest", path));
+        }
 
-		// all model entries second
-		for (String path : models) {
-			steps.add(Collections.singletonMap("model", path));
-		}
+        // all model entries second
+        for (String path : models) {
+            steps.add(Collections.singletonMap("model", path));
+        }
 
-		// all nodegroup entries third
-		for (String path : nodegroups) {
-			steps.add(Collections.singletonMap("nodegroups", path));
-		}
+        // all nodegroup entries third
+        for (String path : nodegroups) {
+            steps.add(Collections.singletonMap("nodegroups", path));
+        }
 
-		// all data entries fourth; most importantly after models
-		for (String path : datas) {
-			steps.add(Collections.singletonMap("data", path));
-		}
+        // all data entries fourth; most importantly after models
+        for (String path : datas) {
+            steps.add(Collections.singletonMap("data", path));
+        }
 
-		if (performEntityResolution != null) {
-			content.put(PERFORM_ENTITY_RESOLUTION_KEY, performEntityResolution);
-		}
+        if (performEntityResolution != null) {
+            content.put(PERFORM_ENTITY_RESOLUTION_KEY, performEntityResolution);
+        }
 
-		if (copyToGraph != null) {
-			content.put(COPY_TO_GRAPH_KEY, copyToGraph);
-		}
+        if (copyToGraph != null) {
+            content.put(COPY_TO_GRAPH_KEY, copyToGraph);
+        }
 
-		writeManifest(project, content);
-	}
+        writeManifest(project, content);
+    }
 
-	@Override
-	public Object execute(ExecutionEvent event) throws ExecutionException {
-		// Ensure all the projects are visited at least once.
-		// Duplicate visits due to references will be skipped.
-		visitedProjects.clear();
-		for (IProject project : ResourcesPlugin.getWorkspace().getRoot().getProjects()) {
-			regenerateProjectManifest(project);
-		}
-		return null;
-	}
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        // Ensure all the projects are visited at least once.
+        // Duplicate visits due to references will be skipped.
+        visitedProjects.clear();
+        for (IProject project : ResourcesPlugin.getWorkspace().getRoot().getProjects()) {
+            regenerateProjectManifest(project);
+        }
+        return null;
+    }
 }

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/SetProjectTypeHandler.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/SetProjectTypeHandler.java
@@ -33,6 +33,7 @@ package com.ge.research.rack;
 
 import com.ge.research.rack.utils.RackConsole;
 import com.ge.research.rack.views.RackPreferencePage;
+
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/ShowNumTriplesHandler.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/ShowNumTriplesHandler.java
@@ -34,7 +34,7 @@ package com.ge.research.rack;
 import com.ge.research.rack.utils.ConnectionUtil;
 import com.ge.research.rack.utils.RackConsole;
 import com.ge.research.semtk.resultSet.TableResultSet;
-import java.util.ArrayList;
+
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
@@ -51,6 +51,8 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
+
+import java.util.ArrayList;
 
 public class ShowNumTriplesHandler extends AbstractHandler {
 

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/UploadIngestionPackageHandler.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/UploadIngestionPackageHandler.java
@@ -36,22 +36,7 @@ import com.ge.research.rack.utils.RackConsole;
 import com.ge.research.rack.views.RackPreferencePage;
 import com.ge.research.semtk.services.client.RestClientConfig;
 import com.ge.research.semtk.services.client.UtilityClient;
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Optional;
-import java.util.stream.Stream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
+
 import org.apache.commons.io.FilenameUtils;
 import org.apache.jena.ext.com.google.common.base.Strings;
 import org.eclipse.core.commands.AbstractHandler;
@@ -70,6 +55,23 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.handlers.HandlerUtil;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Optional;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 public class UploadIngestionPackageHandler extends AbstractHandler {
 
@@ -151,29 +153,29 @@ public class UploadIngestionPackageHandler extends AbstractHandler {
 
             // If the selection is a zip file, upload otherwise zip and upload
             final Path ingestionZipPath;
- 
-            if(selectedProject.get().isFile()) {
-            	
-            	ingestionZipPath = selectedProjectPath;
-            	
+
+            if (selectedProject.get().isFile()) {
+
+                ingestionZipPath = selectedProjectPath;
+
             } else {
-            	
-            	final String newFilepath = promptForSaveFilepath(
-                        selectedProjectPath, HandlerUtil.getActiveShell(event));
-            	
-            	// If the user clicks cancel on prompt
-                if(Strings.isNullOrEmpty(newFilepath)) {
-                	endRun();
-                	return null;
+
+                final String newFilepath =
+                        promptForSaveFilepath(
+                                selectedProjectPath, HandlerUtil.getActiveShell(event));
+
+                // If the user clicks cancel on prompt
+                if (Strings.isNullOrEmpty(newFilepath)) {
+                    endRun();
+                    return null;
                 }
-                
+
                 ingestionZipPath = Paths.get(newFilepath);
-            	
             }
-            
+
             // End run is called in the async callback
-            new IngestionPackageUploadJob(selectedProjectPath, ingestionZipPath, 
-            		() -> endRun()).schedule();
+            new IngestionPackageUploadJob(selectedProjectPath, ingestionZipPath, () -> endRun())
+                    .schedule();
 
         } catch (final Exception e) {
 
@@ -194,8 +196,7 @@ public class UploadIngestionPackageHandler extends AbstractHandler {
 
         final String defaultZipName =
                 String.format(
-                        PACKAGE_NAME_FORMAT.format(new Date()), 
-                        selectedProjectPath.getFileName());
+                        PACKAGE_NAME_FORMAT.format(new Date()), selectedProjectPath.getFileName());
 
         fileDialog.setFileName(defaultZipName);
 

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/UploadNodegroupsHandler.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/UploadNodegroupsHandler.java
@@ -33,12 +33,7 @@ package com.ge.research.rack;
 
 import com.ge.research.rack.report.utils.RackQueryUtils;
 import com.ge.research.rack.utils.RackConsole;
-import java.io.File;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.eclipse.core.commands.AbstractHandler;
@@ -57,6 +52,13 @@ import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.handlers.HandlerUtil;
+
+import java.io.File;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class UploadNodegroupsHandler extends AbstractHandler {
 

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/UploadOwlModelsHandler.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/UploadOwlModelsHandler.java
@@ -36,16 +36,18 @@ import com.ge.research.rack.utils.ProjectUtils;
 import com.ge.research.rack.utils.RackConsole;
 import com.ge.research.rack.views.OntologyTreeView;
 import com.ge.research.semtk.sparqlX.client.SparqlQueryClient;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.handlers.HandlerUtil;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public class UploadOwlModelsHandler extends AbstractHandler {
 

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/helpers/GsnNode2DotPrinter.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/helpers/GsnNode2DotPrinter.java
@@ -34,6 +34,7 @@ package com.ge.research.rack.autoGsn.helpers;
 import com.ge.research.rack.autoGsn.constants.GsnCoreElements;
 import com.ge.research.rack.autoGsn.structures.GsnNode;
 import com.ge.research.rack.autoGsn.utils.CustomStringUtils;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/logic/DataProcessor.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/logic/DataProcessor.java
@@ -38,6 +38,7 @@ import com.ge.research.rack.autoGsn.structures.InstanceData;
 import com.ge.research.rack.autoGsn.structures.PatternInfo;
 import com.ge.research.rack.autoGsn.utils.ListStratPatUtils;
 import com.ge.research.rack.autoGsn.utils.QueryResultUtils;
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/logic/GsnPathInferenceEngine.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/logic/GsnPathInferenceEngine.java
@@ -40,9 +40,11 @@ import com.ge.research.rack.report.structures.SparqlConnectionInfo;
 import com.ge.research.rack.report.utils.RackQueryUtils;
 import com.ge.research.semtk.edc.client.OntologyInfoClient;
 import com.ge.research.semtk.edc.client.OntologyInfoClientConfig;
+
+import org.json.simple.JSONObject;
+
 import java.util.ArrayList;
 import java.util.List;
-import org.json.simple.JSONObject;
 
 /**
  * @author Saswata Paul

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/structures/GsnNode.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/structures/GsnNode.java
@@ -33,6 +33,7 @@ package com.ge.research.rack.autoGsn.structures;
 
 import com.ge.research.rack.autoGsn.constants.GsnCoreElements;
 import com.ge.research.rack.autoGsn.constants.RackCoreElements;
+
 import java.util.List;
 
 /**

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/structures/MultiClassPackets.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/structures/MultiClassPackets.java
@@ -31,8 +31,9 @@
  */
 package com.ge.research.rack.autoGsn.structures;
 
-import java.util.List;
 import javafx.scene.control.TreeItem;
+
+import java.util.List;
 
 /**
  * @author Saswata Paul

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/structures/PatternInfo.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/structures/PatternInfo.java
@@ -31,9 +31,10 @@
  */
 package com.ge.research.rack.autoGsn.structures;
 
+import org.json.simple.JSONObject;
+
 import java.util.ArrayList;
 import java.util.List;
-import org.json.simple.JSONObject;
 
 /**
  * @author Saswata Paul

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/utils/AutoGsnGuiUtils.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/utils/AutoGsnGuiUtils.java
@@ -37,19 +37,22 @@ import com.ge.research.rack.autoGsn.structures.GsnViewsStore;
 import com.ge.research.rack.autoGsn.structures.InstanceData;
 import com.ge.research.rack.autoGsn.structures.MultiClassPackets.GoalIdAndClass;
 import com.ge.research.rack.autoGsn.viewManagers.AutoGsnViewsManager;
+
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+import javafx.scene.paint.Color;
+
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Platform;
+import org.osgi.framework.Bundle;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
-import javafx.scene.paint.Color;
-import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Platform;
-import org.osgi.framework.Bundle;
 
 /**
  * backend for Gsn gui

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/utils/GraphVizUtils.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/utils/GraphVizUtils.java
@@ -36,6 +36,7 @@ import guru.nidi.graphviz.engine.Graphviz;
 import guru.nidi.graphviz.engine.GraphvizV8Engine;
 import guru.nidi.graphviz.model.MutableGraph;
 import guru.nidi.graphviz.parse.Parser;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/utils/GsnNode2GsnSadlUtils.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/utils/GsnNode2GsnSadlUtils.java
@@ -35,6 +35,7 @@ import com.ge.research.rack.autoGsn.constants.GsnCoreElements;
 import com.ge.research.rack.autoGsn.structures.GsnNode;
 import com.ge.research.rack.autoGsn.structures.GsnSadl;
 import com.ge.research.rack.autoGsn.structures.InstanceData;
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/utils/GsnNodeUtils.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/utils/GsnNodeUtils.java
@@ -33,6 +33,7 @@ package com.ge.research.rack.autoGsn.utils;
 
 import com.ge.research.rack.autoGsn.constants.GsnCoreElements;
 import com.ge.research.rack.autoGsn.structures.GsnNode;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/utils/InterfacingUtils.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/utils/InterfacingUtils.java
@@ -36,6 +36,7 @@ import com.ge.research.rack.autoGsn.constants.RackConstants;
 import com.ge.research.rack.autoGsn.helpers.GsnNode2DotPrinter;
 import com.ge.research.rack.autoGsn.structures.GsnNode;
 import com.ge.research.rack.autoGsn.structures.InstanceData;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/utils/ListStratPatUtils.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/utils/ListStratPatUtils.java
@@ -32,6 +32,7 @@
 package com.ge.research.rack.autoGsn.utils;
 
 import com.ge.research.rack.autoGsn.structures.PatternInfo;
+
 import java.util.List;
 
 /**

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/utils/OntologyJsonObjUtils.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/utils/OntologyJsonObjUtils.java
@@ -31,11 +31,12 @@
  */
 package com.ge.research.rack.autoGsn.utils;
 
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
 
 /**
  * @author Saswata Paul

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/utils/QueryGenerationUtils.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/utils/QueryGenerationUtils.java
@@ -34,9 +34,11 @@ package com.ge.research.rack.autoGsn.utils;
 import com.ge.research.rack.autoGsn.constants.PrefixedPatternQueries;
 import com.ge.research.rack.autoGsn.constants.QueryTemplates;
 import com.ge.research.rack.report.structures.SparqlConnectionInfo;
+
+import org.json.simple.JSONObject;
+
 import java.io.IOException;
 import java.util.List;
-import org.json.simple.JSONObject;
 
 /**
  * @author Saswata Paul

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/utils/QueryResultUtils.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/utils/QueryResultUtils.java
@@ -35,6 +35,7 @@ import com.ge.research.rack.autoGsn.structures.MultiClassPackets;
 import com.ge.research.rack.autoGsn.structures.MultiClassPackets.GoalIdAndClass;
 import com.ge.research.rack.autoGsn.structures.PatternInfo;
 import com.ge.research.rack.report.utils.RackQueryUtils;
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/viewHandlers/AutoGsnUnifiedDrillGoalViewHandler.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/viewHandlers/AutoGsnUnifiedDrillGoalViewHandler.java
@@ -41,8 +41,7 @@ import com.ge.research.rack.autoGsn.utils.GsnNodeUtils;
 import com.ge.research.rack.autoGsn.viewManagers.AutoGsnViewsManager;
 import com.ge.research.rack.autoGsn.viewManagers.GsnTreeViewManager;
 import com.ge.research.rack.report.utils.ReportViewUtils;
-import java.util.ArrayList;
-import java.util.List;
+
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
@@ -65,6 +64,9 @@ import javafx.scene.layout.BackgroundFill;
 import javafx.scene.layout.CornerRadii;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Saswata Paul

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/viewHandlers/AutoGsnUnifiedMainViewHandler.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/viewHandlers/AutoGsnUnifiedMainViewHandler.java
@@ -44,8 +44,7 @@ import com.ge.research.rack.report.structures.SparqlConnectionInfo;
 import com.ge.research.rack.report.utils.RackQueryUtils;
 import com.ge.research.rack.report.utils.ReportViewUtils;
 import com.ge.research.rack.views.RackPreferencePage;
-import java.util.ArrayList;
-import java.util.List;
+
 import javafx.collections.ObservableList;
 import javafx.concurrent.Task;
 import javafx.event.ActionEvent;
@@ -65,6 +64,9 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.GridPane;
 import javafx.util.Duration;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Saswata Paul

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/viewHandlers/GsnTreeViewHandler.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/viewHandlers/GsnTreeViewHandler.java
@@ -35,6 +35,7 @@ import com.ge.research.rack.autoGsn.structures.GsnNode;
 import com.ge.research.rack.autoGsn.structures.MultiClassPackets;
 import com.ge.research.rack.autoGsn.structures.MultiClassPackets.TreeItemAndBoolean;
 import com.ge.research.rack.autoGsn.utils.AutoGsnGuiUtils;
+
 import javafx.fxml.FXML;
 import javafx.geometry.Insets;
 import javafx.scene.Node;

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/viewManagers/AutoGsnViewsManager.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/viewManagers/AutoGsnViewsManager.java
@@ -35,19 +35,22 @@ import com.ge.research.rack.autoGsn.logic.GsnPathInferenceEngine;
 import com.ge.research.rack.autoGsn.structures.GsnViewsStore;
 import com.ge.research.rack.autoGsn.structures.InstanceData;
 import com.ge.research.rack.autoGsn.structures.MultiClassPackets.GoalIdAndClass;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
+
 import javafx.application.Application;
 import javafx.application.HostServices;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.osgi.framework.Bundle;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Saswata Paul Note: This class manages all the views for the AutoGsn feature. It also

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/viewManagers/GsnTreeViewManager.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/autoGsn/viewManagers/GsnTreeViewManager.java
@@ -31,16 +31,18 @@
  */
 package com.ge.research.rack.autoGsn.viewManagers;
 
-import java.net.URL;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.osgi.framework.Bundle;
+
+import java.net.URL;
 
 /**
  * @author Saswata Paul Note: This class manages all the GsnTreeView for the AutoGsn feature.

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/report/boeingPsac/PsacDataProcessorBoeing.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/report/boeingPsac/PsacDataProcessorBoeing.java
@@ -43,10 +43,12 @@ import com.ge.research.rack.report.utils.LogicUtils;
 import com.ge.research.rack.report.utils.PsacNodeUtils;
 import com.ge.research.rack.report.utils.RackQueryUtils;
 import com.ge.research.rack.utils.CSVUtil;
+
+import org.apache.commons.io.FileUtils;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.io.FileUtils;
 
 /**
  * @author Saswata Paul

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/report/utils/LogicUtils.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/report/utils/LogicUtils.java
@@ -35,9 +35,11 @@ import com.ge.research.rack.report.structures.PsacNode;
 import com.ge.research.rack.report.structures.Requirement;
 import com.ge.research.rack.report.structures.ReviewLog;
 import com.ge.research.rack.report.structures.Test;
+
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author Saswata Paul

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/report/utils/PsacNodeUtils.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/report/utils/PsacNodeUtils.java
@@ -32,6 +32,7 @@
 package com.ge.research.rack.report.utils;
 
 import com.ge.research.rack.report.structures.PsacNode;
+
 import java.util.List;
 
 /**

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/report/utils/RackQueryUtils.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/report/utils/RackQueryUtils.java
@@ -43,6 +43,9 @@ import com.ge.research.semtk.nodeGroupStore.client.NodeGroupStoreConfig;
 import com.ge.research.semtk.nodeGroupStore.client.NodeGroupStoreRestClient;
 import com.ge.research.semtk.sparqlX.SparqlConnection;
 import com.ge.research.semtk.sparqlX.SparqlEndpointInterface;
+
+import org.apache.commons.io.FileUtils;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileWriter;
@@ -55,7 +58,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.io.FileUtils;
 
 /**
  * @author Saswata Paul

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/report/utils/ReportViewUtils.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/report/utils/ReportViewUtils.java
@@ -39,9 +39,7 @@ import com.ge.research.rack.report.structures.PsacNode;
 import com.ge.research.rack.report.structures.Requirement;
 import com.ge.research.rack.report.structures.ReviewLog;
 import com.ge.research.rack.report.structures.Test;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+
 import javafx.geometry.Pos;
 import javafx.scene.Group;
 import javafx.scene.Node;
@@ -53,6 +51,10 @@ import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
 import javafx.util.Duration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author Saswata Paul

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/report/viewHandlers/ReportMainViewHandlerNew.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/report/viewHandlers/ReportMainViewHandlerNew.java
@@ -38,11 +38,7 @@ import com.ge.research.rack.report.structures.PsacNode;
 import com.ge.research.rack.report.utils.PsacNodeUtils;
 import com.ge.research.rack.report.utils.ReportViewUtils;
 import com.ge.research.rack.report.viewManagers.ReportViewsManager;
-import java.io.File;
-import java.io.FileInputStream;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
+
 import javafx.concurrent.Task;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
@@ -60,10 +56,17 @@ import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.GridPane;
+
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.osgi.framework.Bundle;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Saswata Paul

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/report/viewHandlers/ReportObjectiveViewHandlerNew.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/report/viewHandlers/ReportObjectiveViewHandlerNew.java
@@ -41,10 +41,7 @@ import com.ge.research.rack.report.utils.LogicUtils;
 import com.ge.research.rack.report.utils.PsacNodeUtils;
 import com.ge.research.rack.report.utils.ReportViewUtils;
 import com.ge.research.rack.report.viewManagers.ReportViewsManager;
-import java.io.File;
-import java.io.FileInputStream;
-import java.net.URL;
-import java.util.List;
+
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.event.ActionEvent;
@@ -64,10 +61,16 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseEvent;
+
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.osgi.framework.Bundle;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.net.URL;
+import java.util.List;
 
 /**
  * @author Saswata Paul

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/report/viewHandlers/ReportTableViewHandlerNew.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/report/viewHandlers/ReportTableViewHandlerNew.java
@@ -36,11 +36,7 @@ import com.ge.research.rack.report.structures.PsacNode;
 import com.ge.research.rack.report.utils.PsacNodeUtils;
 import com.ge.research.rack.report.utils.ReportViewUtils;
 import com.ge.research.rack.report.viewManagers.ReportViewsManager;
-import java.io.File;
-import java.io.FileInputStream;
-import java.net.URL;
-import java.util.Collections;
-import java.util.List;
+
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
@@ -56,10 +52,17 @@ import javafx.scene.control.SelectionMode;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseEvent;
+
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.osgi.framework.Bundle;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author Saswata Paul

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/report/viewManagers/ReportViewsManager.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/report/viewManagers/ReportViewsManager.java
@@ -32,7 +32,7 @@
 package com.ge.research.rack.report.viewManagers;
 
 import com.ge.research.rack.report.structures.PsacNode;
-import java.net.URL;
+
 import javafx.application.Application;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.DoubleProperty;
@@ -41,10 +41,13 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.osgi.framework.Bundle;
+
+import java.net.URL;
 
 /**
  * @author Saswata Paul

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/utils/CSVUtil.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/utils/CSVUtil.java
@@ -35,6 +35,9 @@ import com.ge.research.rack.views.RackPreferencePage;
 import com.ge.research.semtk.resultSet.TableResultSet;
 import com.opencsv.CSVReader;
 import com.opencsv.CSVWriter;
+
+import org.apache.commons.io.FileUtils;
+
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
@@ -44,7 +47,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.io.FileUtils;
 
 public class CSVUtil {
 

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/utils/ConnectionUtil.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/utils/ConnectionUtil.java
@@ -45,6 +45,7 @@ import com.ge.research.semtk.sparqlX.SparqlConnection;
 import com.ge.research.semtk.sparqlX.SparqlEndpointInterface;
 import com.ge.research.semtk.sparqlX.client.SparqlQueryAuthClientConfig;
 import com.ge.research.semtk.sparqlX.client.SparqlQueryClient;
+
 import java.util.List;
 
 public class ConnectionUtil {

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/utils/IngestionTemplateUtil.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/utils/IngestionTemplateUtil.java
@@ -34,6 +34,7 @@ package com.ge.research.rack.utils;
 import com.ge.research.semtk.load.utility.IngestionNodegroupBuilder;
 import com.ge.research.semtk.load.utility.SparqlGraphJson;
 import com.ge.research.semtk.sparqlX.SparqlConnection;
+
 import java.util.*;
 
 public class IngestionTemplateUtil {

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/utils/MyTree.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/utils/MyTree.java
@@ -34,6 +34,7 @@ package com.ge.research.rack.utils;
 import com.ge.research.semtk.ontologyTools.OntologyClass;
 import com.ge.research.semtk.ontologyTools.OntologyInfo;
 import com.ge.research.semtk.ontologyTools.OntologyProperty;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/utils/NodegroupUtil.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/utils/NodegroupUtil.java
@@ -35,6 +35,7 @@ import com.ge.research.rack.views.RackPreferencePage;
 import com.ge.research.semtk.nodeGroupStore.client.NodeGroupStoreConfig;
 import com.ge.research.semtk.nodeGroupStore.client.NodeGroupStoreRestClient;
 import com.ge.research.semtk.resultSet.TableResultSet;
+
 import java.util.*;
 
 public class NodegroupUtil {

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/utils/OntologyUtil.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/utils/OntologyUtil.java
@@ -37,6 +37,7 @@ import com.ge.research.semtk.ontologyTools.*;
 import com.ge.research.semtk.ontologyTools.OntologyClass;
 import com.ge.research.semtk.ontologyTools.OntologyInfo;
 import com.ge.research.semtk.sparqlX.SparqlConnection;
+
 import java.util.*;
 
 public class OntologyUtil {

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/utils/OwlUtil.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/utils/OwlUtil.java
@@ -31,12 +31,6 @@
  */
 package com.ge.research.rack.utils;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Map;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.ontology.OntModelSpec;
@@ -47,6 +41,13 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Map;
 
 public class OwlUtil {
 

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/utils/ProjectUtils.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/utils/ProjectUtils.java
@@ -32,14 +32,7 @@
 package com.ge.research.rack.utils;
 
 import com.ge.research.rack.views.RackPreferencePage;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.StringWriter;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+
 import org.apache.commons.io.FileUtils;
 import org.eclipse.core.internal.resources.ICoreConstants;
 import org.eclipse.core.internal.resources.Workspace;
@@ -55,6 +48,15 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.yaml.snakeyaml.*;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.StringWriter;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 public class ProjectUtils {
     public static boolean isOverlaySelected = false;

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/utils/RackConsole.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/utils/RackConsole.java
@@ -32,6 +32,7 @@
 package com.ge.research.rack.utils;
 
 import com.ge.research.rack.views.ViewUtils;
+
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.ui.console.ConsolePlugin;
 import org.eclipse.ui.console.IConsole;

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/views/AssuranceCaseTree.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/views/AssuranceCaseTree.java
@@ -35,9 +35,7 @@ import com.ge.research.rack.LoadAssuranceCaseHandler;
 import com.ge.research.rack.utils.*;
 import com.ge.research.rack.utils.TreeNode;
 import com.google.inject.*;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Set;
+
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.action.*;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -48,6 +46,10 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.ui.*;
 import org.eclipse.ui.part.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Set;
 
 /**
  * This sample class demonstrates how to plug-in a new workbench view. The view shows data obtained

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/views/IngestionNodegroups.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/views/IngestionNodegroups.java
@@ -37,9 +37,7 @@ import com.ge.research.rack.utils.NodegroupUtil;
 import com.ge.research.rack.utils.ProjectUtils;
 import com.ge.research.rack.utils.RackConsole;
 import com.google.inject.*;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Map;
+
 import org.eclipse.jface.action.*;
 import org.eclipse.jface.viewers.*;
 import org.eclipse.swt.SWT;
@@ -57,6 +55,10 @@ import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.ui.*;
 import org.eclipse.ui.part.*;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Map;
 
 public class IngestionNodegroups extends ViewPart implements INodegroupView {
 

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/views/InstanceDataEditor.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/views/InstanceDataEditor.java
@@ -37,10 +37,7 @@ import com.ge.research.semtk.api.nodeGroupExecution.client.NodeGroupExecutionCli
 import com.ge.research.semtk.sparqlX.SparqlConnection;
 import com.google.inject.*;
 import com.opencsv.CSVWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.util.*;
-import java.util.List;
+
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuListener;
 import org.eclipse.jface.action.IMenuManager;
@@ -60,6 +57,11 @@ import org.eclipse.swt.widgets.*;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchActionConstants;
 import org.eclipse.ui.part.ViewPart;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.util.*;
+import java.util.List;
 
 /**
  * This sample class demonstrates how to plug-in a new workbench view. The view shows data obtained

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/views/NodegroupActionFactory.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/views/NodegroupActionFactory.java
@@ -36,16 +36,18 @@ import com.ge.research.rack.utils.Core;
 import com.ge.research.rack.utils.IngestionTemplateUtil;
 import com.ge.research.rack.utils.ProjectUtils;
 import com.ge.research.rack.utils.RackConsole;
-import java.io.File;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Arrays;
+
 import org.apache.commons.io.*;
 import org.eclipse.jface.action.Action;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 public class NodegroupActionFactory {
     public static Action getCreateInstanceDataAction(INodegroupView view) {

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/views/NodegroupColumnView.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/views/NodegroupColumnView.java
@@ -33,9 +33,7 @@ package com.ge.research.rack.views;
 
 import com.ge.research.rack.utils.IngestionTemplateUtil;
 import com.google.inject.*;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Set;
+
 import org.eclipse.jface.action.*;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.*;
@@ -53,6 +51,10 @@ import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.ui.*;
 import org.eclipse.ui.part.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Set;
 
 /**
  * This sample class demonstrates how to plug-in a new workbench view. The view shows data obtained

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/views/NodegroupTemplateView.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/views/NodegroupTemplateView.java
@@ -33,9 +33,7 @@ package com.ge.research.rack.views;
 
 import com.ge.research.rack.utils.IngestionTemplateUtil;
 import com.google.inject.*;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
+
 import org.eclipse.jface.action.*;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.*;
@@ -49,6 +47,10 @@ import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.ui.*;
 import org.eclipse.ui.part.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 
 /**
  * This sample class demonstrates how to plug-in a new workbench view. The view shows data obtained

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/views/NodegroupsView.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/views/NodegroupsView.java
@@ -36,11 +36,7 @@ import com.ge.research.rack.utils.ConnectionUtil;
 import com.ge.research.rack.utils.NodegroupUtil;
 import com.ge.research.rack.utils.RackConsole;
 import com.google.inject.*;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -66,6 +62,12 @@ import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.*;
 import org.eclipse.ui.part.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class NodegroupsView extends ViewPart implements INodegroupView {
 

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/views/OntologyTreeView.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/views/OntologyTreeView.java
@@ -35,9 +35,7 @@ import com.ge.research.rack.BuildIngestionNodegroupsHandler;
 import com.ge.research.rack.utils.*;
 import com.ge.research.semtk.resultSet.TableResultSet;
 import com.google.inject.*;
-import java.io.InputStream;
-import java.util.*;
-import java.util.ArrayList;
+
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.action.*;
 import org.eclipse.jface.viewers.*;
@@ -59,6 +57,10 @@ import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.ui.*;
 import org.eclipse.ui.part.*;
+
+import java.io.InputStream;
+import java.util.*;
+import java.util.ArrayList;
 
 /**
  * This sample class demonstrates how to plug-in a new workbench view. The view shows data obtained

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/views/OtherNodegroups.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/views/OtherNodegroups.java
@@ -37,9 +37,7 @@ import com.ge.research.rack.utils.NodegroupUtil;
 import com.ge.research.rack.utils.ProjectUtils;
 import com.ge.research.rack.utils.RackConsole;
 import com.google.inject.*;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Map;
+
 import org.eclipse.jface.action.*;
 import org.eclipse.jface.viewers.*;
 import org.eclipse.swt.SWT;
@@ -55,6 +53,10 @@ import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.ui.*;
 import org.eclipse.ui.part.*;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Map;
 
 /**
  * This sample class demonstrates how to plug-in a new workbench view. The view shows data obtained

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/views/QueryResultsView.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/views/QueryResultsView.java
@@ -34,8 +34,7 @@ package com.ge.research.rack.views;
 import com.ge.research.rack.utils.ConnectionUtil;
 import com.ge.research.rack.utils.RackConsole;
 import com.google.inject.*;
-import java.util.ArrayList;
-import java.util.Arrays;
+
 import org.eclipse.jface.action.*;
 import org.eclipse.jface.viewers.*;
 import org.eclipse.swt.SWT;
@@ -47,6 +46,9 @@ import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.ui.*;
 import org.eclipse.ui.part.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 
 /**
  * This sample class demonstrates how to plug-in a new workbench view. The view shows data obtained

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/views/RackPreferencePage.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/views/RackPreferencePage.java
@@ -32,12 +32,7 @@
 package com.ge.research.rack.views;
 
 import com.ge.research.rack.utils.RackConsole;
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
+
 import org.apache.commons.io.FileUtils;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
@@ -51,6 +46,13 @@ import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 public class RackPreferencePage extends FieldEditorPreferencePage
         implements IWorkbenchPreferencePage {

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/views/RibView.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/views/RibView.java
@@ -31,16 +31,18 @@
  */
 package com.ge.research.rack.views;
 
-import java.net.URL;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.osgi.framework.Bundle;
+
+import java.net.URL;
 
 public class RibView extends Application {
 

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/views/SelectDataGraphsDialog.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/views/SelectDataGraphsDialog.java
@@ -39,8 +39,7 @@ import com.ge.research.rack.utils.RackConsole;
 import com.ge.research.semtk.api.nodeGroupExecution.client.NodeGroupExecutionClient;
 import com.ge.research.semtk.resultSet.TableResultSet;
 import com.ge.research.semtk.sparqlX.SparqlConnection;
-import java.io.File;
-import java.util.ArrayList;
+
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.DisposeEvent;
@@ -61,6 +60,9 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
+
+import java.io.File;
+import java.util.ArrayList;
 
 /** Author: Paul Meng */
 public class SelectDataGraphsDialog extends Dialog {

--- a/tools/rack/rack.plugin/src/com/ge/research/rack/views/ViewUtils.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/views/ViewUtils.java
@@ -32,6 +32,7 @@
 package com.ge.research.rack.views;
 
 import com.ge.research.rack.utils.RackConsole;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.jface.resource.ResourceLocator;
 import org.eclipse.swt.graphics.Image;

--- a/tools/rack/rack.product/rack.product
+++ b/tools/rack/rack.product/rack.product
@@ -15,7 +15,7 @@
    <launcherArgs>
       <programArgs>--launcher.defaultAction openFile --launcher.appendVmargs --launcher.suppressErrors
       </programArgs>
-      <vmArgs>-Dosgi.requiredJavaVersion=11 -Dosgi.dataAreaRequiresExplicitInit=true -Dosgi.framework.extensions=org.eclipse.fx.osgi -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true -Xms256m -Xmx2048m --add-modules=ALL-SYSTEM
+      <vmArgs>-Dosgi.requiredJavaVersion=17 -Dosgi.dataAreaRequiresExplicitInit=true -Dosgi.framework.extensions=org.eclipse.fx.osgi -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true -Xms256m -Xmx2048m --add-modules=ALL-SYSTEM
       </vmArgs>
       <vmArgsMac>-Xdock:icon=../Resources/Eclipse.icns -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
@@ -58,7 +58,7 @@
       <property name="preferenceCustomization" value="plugin_customization.ini" />
       <property name="osgi.instance.area.default" value="@user.home/workspace-RITE" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
-      <property name="osgi.requiredJavaVersion" value="11" />
+      <property name="osgi.requiredJavaVersion" value="17" />
       <property name="org.eclipse.update.reconcile" value="false" />
    </configurations>
 

--- a/tools/rack/rack.test/META-INF/MANIFEST.MF
+++ b/tools/rack/rack.test/META-INF/MANIFEST.MF
@@ -5,6 +5,6 @@ Bundle-Vendor: rack
 Bundle-SymbolicName: rack.test
 Bundle-Version: 0.5.0.qualifier
 Fragment-Host: rack.plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit
 Automatic-Module-Name: rack.test


### PR DESCRIPTION
Update pom and manifests to make RITE work with Java 17 and SADL 3.6.0-SNAPSHOT.  Needs to be tested, but should work in Emacs 2022-12.

dependabot.yml: Use more recent link in comment.

integration.yml, main.ymp, release.yml: Change JDK from Java 11 to Java 17.

README.md: Update Java and Eclipse versions in build instructions.

pom.xml: Change compiler from Java 11 to Java 17.  Bump SADL from 3.5.0-SNAPSHOT to 3.6.0-SNAPSHOT.  Bump Tycho from 2.7.5 to 3.0.4 (it's the reason why we have to switch both SADL and RITE to Java 17).

**/MANIFEST.MF: Update JavaSE version.

**/*.java: Automatic formatter changes.

rack.product: Bump Java version to 17.