### PR TITLE
Bump RITE to OSATE 2.12.0

### DIFF
--- a/tools/rack/pom.xml
+++ b/tools/rack/pom.xml
@@ -55,11 +55,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */</copyright.license>
     <!-- Settings of Maven plugins -->
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>17</maven.compiler.release>
     <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
     <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- For multiple dependencies which use the same version -->

--- a/tools/rack/rack.product/rack.product
+++ b/tools/rack/rack.product/rack.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="RACK Product" uid="RITE" id="org.eclipse.platform.ide" application="org.eclipse.ui.ide.workbench" version="0.5.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="RACK Product" uid="RITE" id="org.eclipse.platform.ide" application="org.eclipse.ui.ide.workbench" version="0.6.0.qualifier" useFeatures="true" includeLaunchers="true">
 
    <aboutInfo>
       <text>

--- a/tools/rack/rack.targetplatform/rack.targetplatform.target
+++ b/tools/rack/rack.targetplatform/rack.targetplatform.target
@@ -6,6 +6,7 @@
     <!-- RACK needs these locations (OSATE needs some units too) -->
 
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+      <unit id="org.apache.commons.lang3" version="0.0.0"/>
       <unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.transaction.feature.group" version="0.0.0"/>
@@ -20,14 +21,17 @@
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.m2e.logback.feature.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.mylyn.context_feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.rcp.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.sirius.common.acceleo.aql" version="0.0.0"/>
       <unit id="org.eclipse.sirius.runtime.ide.ui.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.uml2.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.zest.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/releases/2021-06/"/>
+      <repository location="https://download.eclipse.org/releases/2022-06/"/>
+    </location>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+      <unit id="org.eclipse.mylyn.context_feature.feature.group" version="0.0.0"/>
+      <repository location="https://download.eclipse.org/mylyn/releases/3.25"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="com.google.gson" version="0.0.0"/>
@@ -35,12 +39,11 @@
       <unit id="org.apache.commons.collections" version="0.0.0"/>
       <unit id="org.apache.commons.csv" version="0.0.0"/>
       <unit id="org.apache.commons.io" version="0.0.0"/>
-      <unit id="org.apache.commons.lang3" version="0.0.0"/>
       <unit id="org.apache.httpcomponents.httpclient" version="0.0.0"/>
       <unit id="org.slf4j.api" version="0.0.0"/>
       <unit id="org.slf4j.binding.simple" version="0.0.0"/>
       <unit id="org.yaml.snakeyaml" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/2021-12/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/2022-06/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="com.ge.research.sadl.feature.feature.group" version="0.0.0"/>
@@ -57,7 +60,6 @@
       <unit id="org.osate.alisa.workbench.sdk.feature.group" version="0.0.0"/>
       <unit id="org.osate.ba.feature.feature.group" version="0.0.0"/>
       <unit id="org.osate.core.feature.feature.group" version="0.0.0"/>
-      <unit id="org.osate.dependencies.birt.feature.group" version="0.0.0"/>
       <unit id="org.osate.examples.feature.feature.group" version="0.0.0"/>
       <unit id="org.osate.ge.ba.feature.feature.group" version="0.0.0"/>
       <unit id="org.osate.ge.errormodel.feature.feature.group" version="0.0.0"/>
@@ -65,7 +67,7 @@
       <unit id="org.osate.plugins.feature.feature.group" version="0.0.0"/>
       <unit id="org.osate.utils.feature.feature.group" version="0.0.0"/>
       <unit id="org.osate.xtext.aadl2.errormodel.feature.feature.group" version="0.0.0"/>
-      <repository location="https://osate-build.sei.cmu.edu/download/osate/stable/2.10.2-vfinal/updates/"/>
+      <repository location="https://osate-build.sei.cmu.edu/download/osate/stable/2.12.0-vfinal/updates/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="org.eclipse.birt.chart.engine" version="0.0.0"/>
@@ -101,27 +103,27 @@
       <unit id="org.eclipse.birt.report.item.crosstab.core" version="0.0.0"/>
       <unit id="org.eclipse.birt.report.model" version="0.0.0"/>
       <unit id="uk.co.spudsoft.birt.emitters.excel" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/birt/update-site/2018-09-interim/"/>
+      <repository location="https://download.eclipse.org/birt/update-site/4.9.0/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="org.eclipse.xtext.generator" version="0.0.0"/>
       <unit id="org.eclipse.xtext.junit4" version="0.0.0"/>
       <unit id="org.eclipse.xtext.redist.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.xtext.testing" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.25.0/"/>
+      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.27.0/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.12.1/"/>
+      <repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.13.0/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="org.eclipse.xsemantics.runtime.feature.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/xsemantics/milestones/1.20/"/>
+      <repository location="https://download.eclipse.org/xsemantics/milestones/1.22/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="org.eclipse.elk.algorithms.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.elk.feature.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/elk/updates/releases/0.7.1/"/>
+      <repository location="https://download.eclipse.org/elk/updates/releases/0.8.1/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="org.eclipse.ease.feature.feature.group" version="0.0.0"/>
@@ -130,7 +132,7 @@
       <unit id="org.eclipse.ease.lang.unittest.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.ease.modules.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.ease.ui.feature.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/ease/release/0.7.0/"/>
+      <repository location="https://download.eclipse.org/ease/release/0.8.0/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="org.py4j.feature.feature.group" version="0.0.0"/>
@@ -144,7 +146,7 @@
     	<unit id="openjfx.standard.feature.feature.group" version="0.0.0"/>
     	<unit id="openjfx.swing.feature.feature.group" version="0.0.0"/>
     	<unit id="openjfx.swt.feature.feature.group" version="0.0.0"/>
-    	<repository location="https://downloads.efxclipse.bestsolution.at/p2-repos/openjfx-16/"/>
+    	<repository location="https://downloads.efxclipse.bestsolution.at/p2-repos/openjfx-17.0.2/"/>
     </location>
   </locations>
 </target>


### PR DESCRIPTION
pom.xml: Bump Java from 11 to 17 in case OSATE has Java 17 class files.  Can try downgrading later.

rack.product: Bump version to 0.6.0.qualifier.  Need to edit poms to change version to 0.6.0-SNAPSHOT too.

rack.targetplatform.target: Move lang3 from ORBIT update site to Eclipse update site.  Move mylyn to its own update site.  Remove now-empty osate.dependencies.birt feature.  Bump update sites' versions to match versions used in OSATE 2.12.0's platform.

Note, we didn't wait for the build to finish yet.