### PR TITLE
Fixing the sizing of components in the Ontology View

### DIFF
--- a/tools/rack/rack.plugin/src/com/ge/research/rack/views/OntologyTreeView.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/views/OntologyTreeView.java
@@ -40,6 +40,7 @@ import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.action.*;
 import org.eclipse.jface.viewers.*;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.graphics.Image;
@@ -390,20 +391,17 @@ public class OntologyTreeView extends ViewPart implements INodegroupView {
             if (!hasTriplesCount(graphInfo)) {
                 return;
             }
-            Composite mainComposite = new Composite(parent, SWT.NONE);
+            Composite scComposite = new ScrolledComposite(parent, SWT.H_SCROLL|SWT.V_SCROLL);
+            Composite mainComposite = new Composite(scComposite, SWT.NONE);
             mainComposite.setLayout(new FillLayout());
             Table table = new Table(mainComposite, SWT.NONE);
             table.setHeaderVisible(true);
             table.setLinesVisible(false);
             table.setFocus();
-            table.setSize(500, 500);
             TableColumn dataGraphHeader = new TableColumn(table, SWT.CENTER);
             dataGraphHeader.setText("Data graph");
-            dataGraphHeader.setWidth(300);
-            dataGraphHeader.pack();
             TableColumn numTriples = new TableColumn(table, SWT.CENTER);
             numTriples.setText("# Triples");
-            numTriples.pack();
             int numRows = graphInfo.getTable().getNumRows();
             for (int i = 0; i < numRows; i++) {
                 TableItem item = new TableItem(table, SWT.CENTER);
@@ -422,8 +420,11 @@ public class OntologyTreeView extends ViewPart implements INodegroupView {
                             parent.dispose();
                         }
                     });
+            numTriples.pack();
+            dataGraphHeader.pack();
             table.pack();
             mainComposite.pack();
+            scComposite.pack();
         } catch (Exception e) {
             RackConsole.getConsole().error("Unable to fetch data graphs on RACK");
         }


### PR DESCRIPTION
**Background**:
The nodegroup view table and ontology tables have fixed sizing and do not fill their parent panels and do not scale/respond to panel size changes.

**Acceptance Criteria**:

- [ ] nodegroup table should scale with panel size changes 
- [x] ontology panel tables should scale with panel size changes

Partial fix for [94](https://github.com/ge-high-assurance/RITE/issues/94)