### PR TITLE
Fixing the selections in the Nodegroup view

### DIFF
--- a/tools/rack/rack.plugin/src/com/ge/research/rack/views/NodegroupActionFactory.java
+++ b/tools/rack/rack.plugin/src/com/ge/research/rack/views/NodegroupActionFactory.java
@@ -39,6 +39,7 @@ import com.ge.research.rack.utils.RackConsole;
 
 import org.apache.commons.io.*;
 import org.eclipse.jface.action.Action;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchWindow;
@@ -162,8 +163,9 @@ public class NodegroupActionFactory {
             public void runWithEvent(Event event) {
                 // nodegroups
                 ArrayList<String> selection = view.getSelectedNodegroups();
-                if (selection.size() == 0) {
-                    return;
+                if (selection.size() != 1) {
+                	MessageDialog.openError(null, "RITE Error", "Query action is permitted only for exactly one selection");
+                	return;
                 }
                 String queryNodegroup = selection.get(0);
                 SelectDataGraphsDialog dialog =


### PR DESCRIPTION
This view allowed both a checkbox selection and a mouse (right-click) selection, and allowed multiple selections. As a result it was confusing/ambiguous as to which nodegroups were being acted on.

- Removed the checkboxes. All selections are done with standard mouse selection.
- The table allows multiple lines to be selected (using shift or command keys), but, for the View and Execute actions, a dialog box complains if there is more than 1 selection.
- Delete acts on all selections. A confirmation box has been added saying how many nodegroups are being deleted.